### PR TITLE
Window size and location storing

### DIFF
--- a/data/com.github.ryonakano.konbucase.gschema.xml
+++ b/data/com.github.ryonakano.konbucase.gschema.xml
@@ -24,5 +24,10 @@
             <summary>Window Height</summary>
             <description>The saved height of the window</description>
         </key>
+        <key name="window-maximized" type="b">
+            <default>false</default>
+            <summary>Window Maximized</summary>
+            <description>The saved value for whether the window is maximized or not</description>
+        </key>
     </schema>
 </schemalist>

--- a/data/com.github.ryonakano.konbucase.gschema.xml
+++ b/data/com.github.ryonakano.konbucase.gschema.xml
@@ -2,13 +2,13 @@
 <schemalist>
     <schema path="/com/github/ryonakano/konbucase/" id="com.github.ryonakano.konbucase">
         <key name="pos-x" type="i">
-            <default>200</default>
+            <default>-1</default>
             <summary>Horizontal Postition</summary>
             <description>The saved horizontal postion of the window</description>
         </key>
 
         <key name="pos-y" type="i">
-            <default>200</default>
+            <default>-1</default>
             <summary>Vertical Postition</summary>
             <description>The saved vertical postion of the window</description>
         </key>

--- a/data/com.github.ryonakano.konbucase.gschema.xml
+++ b/data/com.github.ryonakano.konbucase.gschema.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+    <schema path="/com/github/ryonakano/konbucase/" id="com.github.ryonakano.konbucase">
+        <key name="pos-x" type="i">
+            <default>200</default>
+            <summary>Horizontal Postition</summary>
+            <description>The saved horizontal postion of the window</description>
+        </key>
+
+        <key name="pos-y" type="i">
+            <default>200</default>
+            <summary>Vertical Postition</summary>
+            <description>The saved vertical postion of the window</description>
+        </key>
+
+        <key name="window-width" type="i">
+            <default>600</default>
+            <summary>Window Width</summary>
+            <description>The saved width of the window</description>
+        </key>
+
+        <key name="window-height" type="i">
+            <default>500</default>
+            <summary>Window Height</summary>
+            <description>The saved height of the window</description>
+        </key>
+    </schema>
+</schemalist>

--- a/data/meson.build
+++ b/data/meson.build
@@ -16,7 +16,7 @@ i18n.merge_file(
 )
 
 install_data(
-    'com.github.ryonakano.konbucase.gschema.xml',
+    meson.project_name() + '.gschema.xml',
     install_dir: join_paths(get_option('datadir'), 'glib-2.0', 'schemas'),
     rename: meson.project_name() + '.gschema.xml'
 )

--- a/data/meson.build
+++ b/data/meson.build
@@ -14,3 +14,9 @@ i18n.merge_file(
     install: true,
     install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
+
+install_data(
+    'com.github.ryonakano.konbucase.gschema.xml',
+    install_dir: join_paths(get_option('datadir'), 'glib-2.0', 'schemas'),
+    rename: meson.project_name() + '.gschema.xml'
+)

--- a/meson.build
+++ b/meson.build
@@ -35,3 +35,5 @@ executable(
 
 subdir('data')
 subdir('po')
+
+meson.add_install_script('meson/post_install.py')

--- a/meson.build
+++ b/meson.build
@@ -25,7 +25,7 @@ executable(
     'src/Application.vala',
     'src/MainWindow.vala',
     dependencies: [
-        dependency('granite', version: '>=5.2.3'),
+        dependency('granite'),
         dependency('gdk-3.0'),
         dependency('gtk+-3.0'),
         dependency('gtksourceview-3.0'),

--- a/meson/post_install.py
+++ b/meson/post_install.py
@@ -1,0 +1,11 @@
+#! /usr/bin/env python3
+
+import os
+import subprocess
+
+install_prefix = os.environ['MESON_INSTALL_PREFIX']
+schemadir = os.path.join(install_prefix, 'share/glib-2.0/schemas')
+
+if not os.environ.get('DESTDIR'):
+    print('Compiling the gsettings schemas...')
+    subprocess.call(['glib-compile-schemas', schemadir])

--- a/meson/post_install.py
+++ b/meson/post_install.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 
 install_prefix = os.environ['MESON_INSTALL_PREFIX']
-schemadir = os.path.join(install_prefix, 'share/glib-2.0/schemas')
+schemadir = os.path.join(install_prefix, 'share', 'glib-2.0', 'schemas')
 
 if not os.environ.get('DESTDIR'):
     print('Compiling the gsettings schemas...')

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -17,6 +17,7 @@
 
 public class Application : Gtk.Application {
     private MainWindow window;
+    public static GLib.Settings settings { get; set; }
 
     public Application () {
         Object (
@@ -30,6 +31,8 @@ public class Application : Gtk.Application {
             window.present ();
             return;
         }
+
+        settings = new GLib.Settings ("com.github.ryonakano.konbucase");
 
         window = new MainWindow (this);
         window.show_all ();

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -17,7 +17,6 @@
 
 public class MainWindow : Gtk.ApplicationWindow {
     private Services.Buffer target_source_buffer;
-    private GLib.Settings settings;
 
     private Gtk.Grid buttons_grid;
     private Gtk.ToolButton copy_clipboard_button;
@@ -26,16 +25,23 @@ public class MainWindow : Gtk.ApplicationWindow {
 
     public MainWindow (Application app) {
         Object (
-            application: app,
-            width_request: 600,
-            height_request: 500
+            application: app
         );
     }
 
     construct {
-        settings = new GLib.Settings("com.github.ryonakano.konbucase");
-        move(settings.get_int("pos-x"), settings.get_int("pos-y"));
-        resize(settings.get_int("window-width"), settings.get_int("window-height"));
+        var window_pos_x = Application.settings.get_int ("pos-x");
+        var window_pos_y = Application.settings.get_int ("pos-y");
+        var window_width = Application.settings.get_int ("window-width");
+        var window_height = Application.settings.get_int ("window-height");
+
+        if (window_pos_x != -1 || window_pos_y != -1) {
+            move (window_pos_x, window_pos_y);
+        } else {
+            window_position = Gtk.WindowPosition.CENTER;
+        }
+
+        resize (window_width, window_height);
 
         var cssprovider = new Gtk.CssProvider ();
         cssprovider.load_from_resource ("/com/github/ryonakano/konbucase/Application.css");
@@ -142,21 +148,21 @@ public class MainWindow : Gtk.ApplicationWindow {
             update_header_buttons ();
         });
 
-        delete_event.connect(e => {
-            return before_destroy();
+        delete_event.connect (e => {
+            return before_destroy ();
         });
     }
 
-    private bool before_destroy() {
+    private bool before_destroy () {
         int width, height, x, y;
 
-        get_size(out width, out height);
-        get_position(out x, out y);
+        get_size (out width, out height);
+        get_position (out x, out y);
 
-        settings.set_int("pos-x", x);
-        settings.set_int("pos-y", y);
-        settings.set_int("window-width", width);
-        settings.set_int("window-height", height);
+        Application.settings.set_int ("pos-x", x);
+        Application.settings.set_int ("pos-y", y);
+        Application.settings.set_int ("window-width", width);
+        Application.settings.set_int ("window-height", height);
 
         return false;
     }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -17,6 +17,7 @@
 
 public class MainWindow : Gtk.ApplicationWindow {
     private Services.Buffer target_source_buffer;
+    private GLib.Settings settings;
 
     private Gtk.Grid buttons_grid;
     private Gtk.ToolButton copy_clipboard_button;
@@ -32,6 +33,10 @@ public class MainWindow : Gtk.ApplicationWindow {
     }
 
     construct {
+        settings = new GLib.Settings("com.github.ryonakano.konbucase");
+        move(settings.get_int("pos-x"), settings.get_int("pos-y"));
+        resize(settings.get_int("window-width"), settings.get_int("window-height"));
+
         var cssprovider = new Gtk.CssProvider ();
         cssprovider.load_from_resource ("/com/github/ryonakano/konbucase/Application.css");
         Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (),
@@ -136,6 +141,24 @@ public class MainWindow : Gtk.ApplicationWindow {
             target_source_buffer.redo ();
             update_header_buttons ();
         });
+
+        delete_event.connect(e => {
+            return before_destroy();
+        });
+    }
+
+    private bool before_destroy() {
+        int width, height, x, y;
+
+        get_size(out width, out height);
+        get_position(out x, out y);
+
+        settings.set_int("pos-x", x);
+        settings.set_int("pos-y", y);
+        settings.set_int("window-width", width);
+        settings.set_int("window-height", height);
+
+        return false;
     }
 
     private void update_header_buttons () {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -34,7 +34,11 @@ public class MainWindow : Gtk.ApplicationWindow {
         var window_pos_y = Application.settings.get_int ("pos-y");
         var window_width = Application.settings.get_int ("window-width");
         var window_height = Application.settings.get_int ("window-height");
+        var window_max = Application.settings.get_boolean ("window-maximized");
 
+        if (window_max == true) {
+            maximize ();
+        }
         if (window_pos_x != -1 || window_pos_y != -1) {
             move (window_pos_x, window_pos_y);
         } else {
@@ -155,6 +159,7 @@ public class MainWindow : Gtk.ApplicationWindow {
 
     private bool before_destroy () {
         int width, height, x, y;
+        var max = is_maximized;
 
         get_size (out width, out height);
         get_position (out x, out y);
@@ -163,6 +168,7 @@ public class MainWindow : Gtk.ApplicationWindow {
         Application.settings.set_int ("pos-y", y);
         Application.settings.set_int ("window-width", width);
         Application.settings.set_int ("window-height", height);
+        Application.settings.set_boolean ("window-maximized", max);
 
         return false;
     }


### PR DESCRIPTION
Fixes #8

Added the support for saving the window size and location.
Files added:
 - data/com.github.ryonakano.konbucase.gschema.cml ( gschema file to store the attributes )
 - meson/post_install.py ( Script to re-compile gsettings schemas settings after installation )