### PR TITLE
Improve saving window state

### DIFF
--- a/data/com.github.ryonakano.konbucase.gschema.xml
+++ b/data/com.github.ryonakano.konbucase.gschema.xml
@@ -52,29 +52,18 @@
             <description>Whether to follow system's dark style settings or not</description>
         </key>
 
-        <key name="pos-x" type="i">
-            <default>-1</default>
-            <summary>Horizontal Postition</summary>
-            <description>The saved horizontal postion of the window</description>
+        <key name="window-position" type="(ii)">
+            <default>(-1, -1)</default>
+            <summary>Window Postition</summary>
+            <description>The saved postion of the window</description>
         </key>
 
-        <key name="pos-y" type="i">
-            <default>-1</default>
-            <summary>Vertical Postition</summary>
-            <description>The saved vertical postion of the window</description>
+        <key name="window-size" type="(ii)">
+            <default>(600, 500)</default>
+            <summary>Window Size</summary>
+            <description>The saved size of the window</description>
         </key>
 
-        <key name="window-width" type="i">
-            <default>600</default>
-            <summary>Window Width</summary>
-            <description>The saved width of the window</description>
-        </key>
-
-        <key name="window-height" type="i">
-            <default>500</default>
-            <summary>Window Height</summary>
-            <description>The saved height of the window</description>
-        </key>
         <key name="window-maximized" type="b">
             <default>false</default>
             <summary>Window Maximized</summary>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -17,7 +17,7 @@
 
 public class Application : Gtk.Application {
     private MainWindow window;
-    public static GLib.Settings settings { get; set; }
+    public static GLib.Settings settings;
 
     public Application () {
         Object (
@@ -26,15 +26,35 @@ public class Application : Gtk.Application {
         );
     }
 
+    static construct {
+        settings = new GLib.Settings ("com.github.ryonakano.konbucase");
+    }
+
     protected override void activate () {
         if (window != null) {
             window.present ();
             return;
         }
 
-        settings = new GLib.Settings ("com.github.ryonakano.konbucase");
-
         window = new MainWindow (this);
+
+        int window_pos_x, window_pos_y;
+        Application.settings.get ("window-position", "(ii)", out window_pos_x, out window_pos_y);
+
+        int window_width, window_height;
+        Application.settings.get ("window-size", "(ii)", out window_width, out window_height);
+
+        if (Application.settings.get_boolean ("window-maximized")) {
+            window.maximize ();
+        }
+
+        if (window_pos_x != -1 || window_pos_y != -1) {
+            window.move (window_pos_x, window_pos_y);
+        } else {
+            window.window_position = Gtk.WindowPosition.CENTER;
+        }
+
+        window.resize (window_width, window_height);
         window.show_all ();
     }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -25,24 +25,6 @@ public class MainWindow : Gtk.ApplicationWindow {
     }
 
     construct {
-        int window_pos_x, window_pos_y;
-        Application.settings.get ("window-position", "(ii)", out window_pos_x, out window_pos_y);
-
-        int window_width, window_height;
-        Application.settings.get ("window-size", "(ii)", out window_width, out window_height);
-
-        if (Application.settings.get_boolean ("window-maximized")) {
-            maximize ();
-        }
-
-        if (window_pos_x != -1 || window_pos_y != -1) {
-            move (window_pos_x, window_pos_y);
-        } else {
-            window_position = Gtk.WindowPosition.CENTER;
-        }
-
-        resize (window_width, window_height);
-
         var cssprovider = new Gtk.CssProvider ();
         cssprovider.load_from_resource ("/com/github/ryonakano/konbucase/Application.css");
         Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (),

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -120,7 +120,7 @@ public class MainWindow : Gtk.ApplicationWindow {
             int width, height, x, y;
             get_size (out width, out height);
             get_position (out x, out y);
-    
+
             Application.settings.set ("window-position", "(ii)", x, y);
             Application.settings.set ("window-size", "(ii)", width, height);
             Application.settings.set_boolean ("window-maximized", this.is_maximized);


### PR DESCRIPTION
- Handle window states with fewer keys
- Init `Application.settings` in the explicit static constructor
- Restore window states before `show_all ()` to make sure window states are restored with saved values
- Save the current window state in `configure_event ()` so that it is saved on force-quit
