### PR TITLE
Flatpak: Revoke access to AccountsService

### DIFF
--- a/com.github.ryonakano.konbucase.yml
+++ b/com.github.ryonakano.konbucase.yml
@@ -7,10 +7,6 @@ finish-args:
   - '--share=ipc'
   - '--socket=wayland'
   - '--socket=fallback-x11'
-
-  # needed for perfers-color-scheme
-  - '--system-talk-name=org.freedesktop.Accounts'
-
   - '--metadata=X-DConf=migrate-path=/com/github/ryonakano/konbucase/'
 modules:
   - name: chcase


### PR DESCRIPTION
We don't need this since Flatpak Platform 6.0.2
