### PR TITLE
Fix typo

### DIFF
--- a/data/konbucase.metainfo.xml.in
+++ b/data/konbucase.metainfo.xml.in
@@ -34,8 +34,8 @@
 
   <branding>
     <color type="primary">#f9c440</color>
-    <color type="primary" schema_preference="light">#d48e15</color>
-    <color type="primary" schema_preference="dark">#ffe16b</color>
+    <color type="primary" scheme_preference="light">#d48e15</color>
+    <color type="primary" scheme_preference="dark">#ffe16b</color>
   </branding>
 
   <content_rating type="oars-1.1" />


### PR DESCRIPTION
I'm unsure, if three primary colors is supported at all, but the typo meant, these were not picked up.