### PR TITLE
docs: Default for Flathub, optionally for AppCenter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ We accept changes to the source code through pull requests―even a small typo f
 
 ### Coding Style
 
-We follow [the coding style of elementary OS](https://docs.elementary.io/develop/writing-apps/code-style) and [its Human Interface Guidelines](https://docs.elementary.io/hig/). Try to respect them.
+We follow [the coding style of elementary OS](https://docs.elementary.io/develop/writing-apps/code-style). Try to respect them.
 
 ## Manage the Project
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ Features include:
 * Convert your text between camelCase, PascalCase, Sentence case, snake_case, kebab-case, and space-separated
 
 ## Installation
-### From AppCenter or Flathub (Recommended)
-Click the button to get KonbuCase on AppCenter if you're on elementary OS:
-
-[![Get it on AppCenter](https://appcenter.elementary.io/badge.svg)](https://appcenter.elementary.io/com.github.ryonakano.konbucase)
-
-You can install KonbuCase from Flathub if you're on another distribution:
+### From Flathub or AppCenter (Recommended)
+You can install KonbuCase from Flathub:
 
 [<img src="https://flathub.org/assets/badges/flathub-badge-en.svg" width="160" alt="Download on Flathub">](https://flathub.org/apps/com.github.ryonakano.konbucase)
+
+You should install KonbuCase from AppCenter if you're on elementary OS. This build is optimized for elementary OS:
+
+[![Get it on AppCenter](https://appcenter.elementary.io/badge.svg)](https://appcenter.elementary.io/com.github.ryonakano.konbucase)
 
 ### From Community Packages
 Community packages maintained by volunteers are also available on some distributions:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # KonbuCase
-![App window in the light mode](data/screenshots/pantheon/screenshot-light.png#gh-light-mode-only)
+![App window in the light mode](data/screenshots/gnome/screenshot-light.png#gh-light-mode-only)
 
-![App window in the dark mode](data/screenshots/pantheon/screenshot-dark.png#gh-dark-mode-only)
+![App window in the dark mode](data/screenshots/gnome/screenshot-dark.png#gh-dark-mode-only)
 
 KonbuCase is a small text tool app that allows you convert case in your text.
 

--- a/build-aux/appcenter/com.github.ryonakano.konbucase.Devel.yml
+++ b/build-aux/appcenter/com.github.ryonakano.konbucase.Devel.yml
@@ -34,3 +34,5 @@ modules:
     sources:
       - type: dir
         path: ../../
+      - type: patch
+        path: ../../patches/0001-chore-metainfo-Use-screenshots-taken-on-Pantheon.patch

--- a/com.github.ryonakano.konbucase.yml
+++ b/com.github.ryonakano.konbucase.yml
@@ -34,3 +34,5 @@ modules:
     sources:
       - type: dir
         path: .
+      - type: patch
+        path: patches/0001-chore-metainfo-Use-screenshots-taken-on-Pantheon.patch

--- a/data/konbucase.metainfo.xml.in.in
+++ b/data/konbucase.metainfo.xml.in.in
@@ -23,12 +23,12 @@
   <screenshots>
     <screenshot type="default">
       <caption>App window in the light mode</caption>
-      <image>https://raw.githubusercontent.com/ryonakano/konbucase/4.2.0/data/screenshots/pantheon/screenshot-light.png</image>
+      <image>https://raw.githubusercontent.com/ryonakano/konbucase/4.2.0/data/screenshots/gnome/screenshot-light.png</image>
     </screenshot>
 
     <screenshot>
       <caption>App window in the dark mode</caption>
-      <image>https://raw.githubusercontent.com/ryonakano/konbucase/4.2.0/data/screenshots/pantheon/screenshot-dark.png</image>
+      <image>https://raw.githubusercontent.com/ryonakano/konbucase/4.2.0/data/screenshots/gnome/screenshot-dark.png</image>
     </screenshot>
   </screenshots>
 

--- a/data/konbucase.metainfo.xml.in.in
+++ b/data/konbucase.metainfo.xml.in.in
@@ -23,12 +23,12 @@
   <screenshots>
     <screenshot type="default">
       <caption>App window in the light mode</caption>
-      <image>https://raw.githubusercontent.com/ryonakano/konbucase/4.2.0/data/screenshots/gnome/screenshot-light.png</image>
+      <image>https://raw.githubusercontent.com/ryonakano/konbucase/@VERSION@/data/screenshots/gnome/screenshot-light.png</image>
     </screenshot>
 
     <screenshot>
       <caption>App window in the dark mode</caption>
-      <image>https://raw.githubusercontent.com/ryonakano/konbucase/4.2.0/data/screenshots/gnome/screenshot-dark.png</image>
+      <image>https://raw.githubusercontent.com/ryonakano/konbucase/@VERSION@/data/screenshots/gnome/screenshot-dark.png</image>
     </screenshot>
   </screenshots>
 

--- a/data/meson.build
+++ b/data/meson.build
@@ -30,6 +30,7 @@ desktop_file = i18n.merge_file(
 appstream_conf = configuration_data()
 appstream_conf.set('APP_ID', app_id)
 appstream_conf.set('GETTEXT_PACKAGE', meson.project_name())
+appstream_conf.set('VERSION', meson.project_version())
 appstream_file_in = configure_file(
     input: 'konbucase.metainfo.xml.in.in',
     output: '@0@.metainfo.xml.in'.format(app_id),

--- a/patches/0001-chore-metainfo-Use-screenshots-taken-on-Pantheon.patch
+++ b/patches/0001-chore-metainfo-Use-screenshots-taken-on-Pantheon.patch
@@ -1,0 +1,31 @@
+From 31448fd7fe74571c0f65839f9173fb7ed710ca6a Mon Sep 17 00:00:00 2001
+From: Ryo Nakano <ryonakaknock3@gmail.com>
+Date: Sat, 4 May 2024 22:23:17 +0900
+Subject: [PATCH] chore: metainfo: Use screenshots taken on Pantheon
+
+---
+ data/konbucase.metainfo.xml.in.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/data/konbucase.metainfo.xml.in.in b/data/konbucase.metainfo.xml.in.in
+index 2ca3dda..a693a79 100644
+--- a/data/konbucase.metainfo.xml.in.in
++++ b/data/konbucase.metainfo.xml.in.in
+@@ -23,12 +23,12 @@
+   <screenshots>
+     <screenshot type="default">
+       <caption>App window in the light mode</caption>
+-      <image>https://raw.githubusercontent.com/ryonakano/konbucase/4.2.0/data/screenshots/gnome/screenshot-light.png</image>
++      <image>https://raw.githubusercontent.com/ryonakano/konbucase/4.2.0/data/screenshots/pantheon/screenshot-light.png</image>
+     </screenshot>
+ 
+     <screenshot>
+       <caption>App window in the dark mode</caption>
+-      <image>https://raw.githubusercontent.com/ryonakano/konbucase/4.2.0/data/screenshots/gnome/screenshot-dark.png</image>
++      <image>https://raw.githubusercontent.com/ryonakano/konbucase/4.2.0/data/screenshots/pantheon/screenshot-dark.png</image>
+     </screenshot>
+   </screenshots>
+ 
+-- 
+2.45.0
+

--- a/patches/0001-chore-metainfo-Use-screenshots-taken-on-Pantheon.patch
+++ b/patches/0001-chore-metainfo-Use-screenshots-taken-on-Pantheon.patch
@@ -1,6 +1,6 @@
-From 31448fd7fe74571c0f65839f9173fb7ed710ca6a Mon Sep 17 00:00:00 2001
+From 9f89254c3c1dd773d0deb319a797fb6a08470979 Mon Sep 17 00:00:00 2001
 From: Ryo Nakano <ryonakaknock3@gmail.com>
-Date: Sat, 4 May 2024 22:23:17 +0900
+Date: Sat, 4 May 2024 22:56:57 +0900
 Subject: [PATCH] chore: metainfo: Use screenshots taken on Pantheon
 
 ---
@@ -8,21 +8,21 @@ Subject: [PATCH] chore: metainfo: Use screenshots taken on Pantheon
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/data/konbucase.metainfo.xml.in.in b/data/konbucase.metainfo.xml.in.in
-index 2ca3dda..a693a79 100644
+index adf27b2..c06998c 100644
 --- a/data/konbucase.metainfo.xml.in.in
 +++ b/data/konbucase.metainfo.xml.in.in
 @@ -23,12 +23,12 @@
    <screenshots>
      <screenshot type="default">
        <caption>App window in the light mode</caption>
--      <image>https://raw.githubusercontent.com/ryonakano/konbucase/4.2.0/data/screenshots/gnome/screenshot-light.png</image>
-+      <image>https://raw.githubusercontent.com/ryonakano/konbucase/4.2.0/data/screenshots/pantheon/screenshot-light.png</image>
+-      <image>https://raw.githubusercontent.com/ryonakano/konbucase/@VERSION@/data/screenshots/gnome/screenshot-light.png</image>
++      <image>https://raw.githubusercontent.com/ryonakano/konbucase/@VERSION@/data/screenshots/pantheon/screenshot-light.png</image>
      </screenshot>
  
      <screenshot>
        <caption>App window in the dark mode</caption>
--      <image>https://raw.githubusercontent.com/ryonakano/konbucase/4.2.0/data/screenshots/gnome/screenshot-dark.png</image>
-+      <image>https://raw.githubusercontent.com/ryonakano/konbucase/4.2.0/data/screenshots/pantheon/screenshot-dark.png</image>
+-      <image>https://raw.githubusercontent.com/ryonakano/konbucase/@VERSION@/data/screenshots/gnome/screenshot-dark.png</image>
++      <image>https://raw.githubusercontent.com/ryonakano/konbucase/@VERSION@/data/screenshots/pantheon/screenshot-dark.png</image>
      </screenshot>
    </screenshots>
  


### PR DESCRIPTION
As we did #148 and #154, we now targets Flathub by default and optionally builds for AppCenter. We do the same thing for screenshots/metainfo too.