### PR TITLE
metainfo: Add environment to screenshots

### DIFF
--- a/data/konbucase.metainfo.xml.in.in
+++ b/data/konbucase.metainfo.xml.in.in
@@ -21,12 +21,12 @@
   </description>
 
   <screenshots>
-    <screenshot type="default">
+    <screenshot type="default" environment="@DE@">
       <caption>App window in the light mode</caption>
       <image>https://raw.githubusercontent.com/ryonakano/konbucase/@VERSION@/data/screenshots/@DE@/screenshot-light.png</image>
     </screenshot>
 
-    <screenshot>
+    <screenshot environment="@DE@:dark">
       <caption>App window in the dark mode</caption>
       <image>https://raw.githubusercontent.com/ryonakano/konbucase/@VERSION@/data/screenshots/@DE@/screenshot-dark.png</image>
     </screenshot>


### PR DESCRIPTION
AppCenter 8.0.1 brings support for `environment` property:

https://github.com/elementary/appcenter/releases/tag/8.0.1