### PR TITLE
Actions: Use ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   flatpak-flathub:
     name: Flatpak (Flathub)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -43,7 +43,7 @@ jobs:
 
   flatpak-appcenter:
     name: Flatpak (AppCenter)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -78,7 +78,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     container:
       image: valalang/lint


### PR DESCRIPTION
We run actions in the containers anyway so we don't need to fix the version of host distribution.
