### PR TITLE
fix: meson: Make sure gresource compile depends on metainfo

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -84,7 +84,10 @@ gresource_file_in = configure_file(
 asresources = gnome.compile_resources(
     'as-resources',
     gresource_file_in,
-    dependencies: blueprints,
+    dependencies: [
+        appstream_file,
+        blueprints,
+    ],
     source_dir: 'data',
     c_name: 'as'
 )


### PR DESCRIPTION
Because we bundle the configured metainfo file in the gresource
