### PR TITLE
fix: Add workaround for misaligned heading label in popover on Pantheon

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -10,7 +10,7 @@
 
 /* Workaround for a bug that the heading label is not aligned along with the description label in a popover */
 /* Upstream issue: https://github.com/elementary/stylesheet/issues/1244 */
-/* TODO Remove this class when elementary SDK bundles a new release of Granite that includes an actual fix */
+/* TODO Remove this class when elementary SDK bundles a new release of stylesheet that includes an actual fix */
 popover.background > contents label.heading {
     margin: 0;
 }

--- a/data/Application.css
+++ b/data/Application.css
@@ -7,3 +7,10 @@
     border-spacing: 0.5rem;
     padding: 0.5rem;
 }
+
+/* Workaround for a bug that the heading label is not aligned along with the description label in a popover */
+/* Upstream issue: https://github.com/elementary/stylesheet/issues/1244 */
+/* TODO Remove this class when elementary SDK bundles a new release of Granite that includes an actual fix */
+popover.background > contents label.heading {
+    margin: 0;
+}


### PR DESCRIPTION
## After
![image](https://github.com/user-attachments/assets/9e4c8f69-c33a-4dbf-8ded-ef780d2c0250)

## Before
![image](https://github.com/user-attachments/assets/4bd54d21-b223-496c-b067-aa46b9c19e48)
