### PR TITLE
refactor: Explicitly cast from GLib.Value to uint

### DIFF
--- a/src/View/BasePane.vala
+++ b/src/View/BasePane.vala
@@ -200,12 +200,14 @@ public class View.BasePane : Adw.Bin {
     }
 
     private bool selected_to_case (Binding binding, Value selected, ref Value case_type) {
+        uint pos = (uint) selected;
+
         // No item is selected
-        if (selected == Gtk.INVALID_LIST_POSITION) {
+        if (pos == Gtk.INVALID_LIST_POSITION) {
             return false;
         }
 
-        var selected_item = case_listmodel.get_item ((uint) selected) as Model.CaseListItemModel;
+        var selected_item = case_listmodel.get_item (pos) as Model.CaseListItemModel;
         if (selected_item == null) {
             return false;
         }


### PR DESCRIPTION
The previous Vala code contains implicit cast from GLib.Value to uint when comparing with GTK_INVALID_LIST_POSITION, which results calling `g_value_get_uint()` twice in the generated C code:

```c
#line 204 "../src/View/BasePane.vala"
	if (g_value_get_uint (&_tmp0_) == GTK_INVALID_LIST_POSITION) {
#line 205 "../src/View/BasePane.vala"
		result = FALSE;
#line 205 "../src/View/BasePane.vala"
		return result;
#line 515 "BasePane.c"
	}
#line 208 "../src/View/BasePane.vala"
	_tmp1_ = self->priv->case_listmodel;
#line 208 "../src/View/BasePane.vala"
	_tmp2_ = *selected;
#line 208 "../src/View/BasePane.vala"
	_tmp3_ = g_list_model_get_item ((GListModel*) _tmp1_, g_value_get_uint (&_tmp2_));
#line 208 "../src/View/BasePane.vala"
	_tmp4_ = MODEL_IS_CASE_LIST_ITEM_MODEL (_tmp3_) ? ((ModelCaseListItemModel*) _tmp3_) : NULL;
#line 208 "../src/View/BasePane.vala"
	if (_tmp4_ == NULL) {
#line 208 "../src/View/BasePane.vala"
		_g_object_unref0 (_tmp3_);
#line 529 "BasePane.c"
	}
```

The fixed code now calls `g_value_get_uint()` once and reuse the variable:

```c
#line 203 "../src/View/BasePane.vala"
	_tmp0_ = *selected;
#line 203 "../src/View/BasePane.vala"
	pos = g_value_get_uint (&_tmp0_);
#line 206 "../src/View/BasePane.vala"
	if (pos == GTK_INVALID_LIST_POSITION) {
#line 207 "../src/View/BasePane.vala"
		result = FALSE;
#line 207 "../src/View/BasePane.vala"
		return result;
#line 517 "BasePane.c"
	}
#line 210 "../src/View/BasePane.vala"
	_tmp1_ = self->priv->case_listmodel;
#line 210 "../src/View/BasePane.vala"
	_tmp2_ = g_list_model_get_item ((GListModel*) _tmp1_, pos);
#line 210 "../src/View/BasePane.vala"
	_tmp3_ = MODEL_IS_CASE_LIST_ITEM_MODEL (_tmp2_) ? ((ModelCaseListItemModel*) _tmp2_) : NULL;
#line 210 "../src/View/BasePane.vala"
	if (_tmp3_ == NULL) {
#line 210 "../src/View/BasePane.vala"
		_g_object_unref0 (_tmp2_);
#line 529 "BasePane.c"
	}
```