### PR TITLE
Revert "metainfo: Use revision instead of version for screenshots URL"

### DIFF
--- a/data/konbucase.metainfo.xml.in.in
+++ b/data/konbucase.metainfo.xml.in.in
@@ -24,12 +24,12 @@
   <screenshots>
     <screenshot type="default" environment="@DE@">
       <caption>App window in the light mode</caption>
-      <image>https://raw.githubusercontent.com/ryonakano/konbucase/@APP_REVISION@/data/screenshots/@DE@/screenshot-light.png</image>
+      <image>https://raw.githubusercontent.com/ryonakano/konbucase/@VERSION@/data/screenshots/@DE@/screenshot-light.png</image>
     </screenshot>
 
     <screenshot environment="@DE@:dark">
       <caption>App window in the dark mode</caption>
-      <image>https://raw.githubusercontent.com/ryonakano/konbucase/@APP_REVISION@/data/screenshots/@DE@/screenshot-dark.png</image>
+      <image>https://raw.githubusercontent.com/ryonakano/konbucase/@VERSION@/data/screenshots/@DE@/screenshot-dark.png</image>
     </screenshot>
   </screenshots>
 

--- a/data/meson.build
+++ b/data/meson.build
@@ -39,7 +39,7 @@ appstream_conf.set('APP_ID', app_id)
 appstream_conf.set('GETTEXT_PACKAGE', meson.project_name())
 # Use screenshots taken on Pantheon, which is a publishing requirement for AppCenter, if build with granite.
 appstream_conf.set('DE', get_option('granite').enabled() ? 'pantheon' : 'gnome')
-appstream_conf.set('APP_REVISION', app_revision)
+appstream_conf.set('VERSION', meson.project_version())
 appstream_file_in = configure_file(
   input: 'konbucase.metainfo.xml.in.in',
   output: '@0@.metainfo.xml.in'.format(app_id),

--- a/meson.build
+++ b/meson.build
@@ -22,12 +22,6 @@ if get_option('development')
   app_version += version_suffix
 endif
 
-app_revision = 'main'
-ret = run_command('git', 'rev-parse', 'HEAD', check: false)
-if ret.returncode() == 0
-  app_revision = ret.stdout().strip()
-endif
-
 gnome = import('gnome')
 i18n = import('i18n')
 


### PR DESCRIPTION
Reverts ryonakano/konbucase#230

We won't need this because now that we're going to publish interim releases from the next release cycle.
