### PR TITLE
chore: Drop blueprint-compiler from subprojects

### DIFF
--- a/subprojects/blueprint-compiler.wrap
+++ b/subprojects/blueprint-compiler.wrap
@@ -1,8 +1,0 @@
-[wrap-git]
-directory = blueprint-compiler
-url = https://gitlab.gnome.org/GNOME/blueprint-compiler.git
-revision = v0.20.4
-depth = 1
-
-[provide]
-program_names = blueprint-compiler


### PR DESCRIPTION
Many projects adapt .blp files instead of the traditional .ui files now so recent distributions should provide this as a package these days.
